### PR TITLE
have permission to -> may; on condition that

### DIFF
--- a/COPYING.TGPPL-v2-draft.rst
+++ b/COPYING.TGPPL-v2-draft.rst
@@ -30,11 +30,11 @@ limited period of time.
 Grant of Additional Permission:
 
    When conveying a work based on the Program under sections 5 or 6 of
-   GPLv3, you have permission to delay compliance with the requirements
+   GPLv3, you may delay compliance with the requirements
    of those sections, including the requirement to license the entire
    work as a whole under GPLv3 and the requirement to convey
    Corresponding Source under GPLv3, for a period of up to 12 months
-   from the time of your conveying the work, provided that you grant this same
+   from the time of your conveying the work, on condition that you grant this same
    Exception to your downstream recipients when licensing your work
    under GPLv3 following the period of delay.
 


### PR DESCRIPTION
have permission to -> may: simpler, clearer, consistent with the rest of the license
provided that -> on condition that: avoid the Jacobsen v. Katzer problem by being explicit that this is a condition (see also http://www.adamsdrafting.com/provided-that/, Manual of Style for Contract Drafting 13.547).
